### PR TITLE
NEW targets: MTB_MURATA_ABZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,18 @@
 
 Feel free to propose your custom boards support in mbed-os!
 
+
 Table of Contents
 =================
 
 * [Usage](#usage)
 * [STM32F1](#stm32f1)
    * [BLUEPILL](#bluepill)
+* [STM32WL](#stm32wl)
+   * [LORA_E5](#lora_e5)
 * [STM32L4](#stm32l4)
-   * [STWIN](#stwin)
+   * [STWIN SensorTile Wireless Industrial Node development kit](#stwin-sensortile-wireless-industrial-node-development-kit)
+* [STM32WL](#stm32wl)
 * [STM32WL](#stm32wl)
    * [Seeed Studio LoRa E5](#seeed-studio-lora-e5)
    * [Charles's LoRa-E5 breakout board](#charless-lora-e5-breakout-board)
@@ -57,20 +61,68 @@ mbedtools compile -m XXX -t XXX
 
 ## BLUEPILL
 
+<img src="https://stm32-base.org/assets/img/boards/STM32F103C8T6_Blue_Pill-1.jpg">
+
 MCU: STM32F103C8T6
+
+TARGET: BLUEPILL_F103C8
+
+
 
 source: https://os.mbed.com/users/hudakz/code/mbed-os-bluepill/
 
  (https://os.mbed.com/users/hudakz/code/STM32F103C8T6_Hello/)
 
 
+# STM32L0
+
+## MURATA LPWAN Wireless Module
+
+MCU: STM32L082CZ
+
+TARGET: MTB_MURATA_ABZ
+
+https://wireless.murata.com/type-abz-078.html
+
+- LORA is not enabled by default. You need to update your local mbed_app.json file:
+
+```
+{
+    "target_overrides": {
+        "MTB_MURATA_ABZ": {
+            "target.components_add":            ["SX1276"],
+            "sx1276-lora-driver.spi-mosi":       "PA_7",
+            "sx1276-lora-driver.spi-miso":       "PA_6",
+            "sx1276-lora-driver.spi-sclk":       "PB_3",
+            "sx1276-lora-driver.spi-cs":         "PA_15",
+            "sx1276-lora-driver.reset":          "PC_0",
+            "sx1276-lora-driver.dio0":           "PB_4",
+            "sx1276-lora-driver.dio1":           "PB_1",
+            "sx1276-lora-driver.dio2":           "PB_0",
+            "sx1276-lora-driver.dio3":           "PC_13",
+            "sx1276-lora-driver.txctl":          "PC_2",
+            "sx1276-lora-driver.rxctl":          "PA_1",
+            "sx1276-lora-driver.pwr-amp-ctl":    "PC_1",
+            "sx1276-lora-driver.tcxo":           "PA_12"
+        }
+    }
+}
+```
+
+
 # STM32L4
 
-## STWIN
+## STWIN SensorTile Wireless Industrial Node development kit
 
 MCU: STM32L4R9ZI
 
+<img src="https://www.st.com/bin/ecommerce/api/image.PF268005.en.feature-description-include-personalized-no-cpn-large.jpg">
+
+TARGET: STWIN
+
 https://www.st.com/en/evaluation-tools/steval-stwinkt1.html
+
+- BLE is enabled by default
 
 
 # STM32WL
@@ -79,9 +131,13 @@ https://www.st.com/en/evaluation-tools/steval-stwinkt1.html
 
 MCU: STM32WLE5JC
 
+TARGET: LORA_E5
+
 https://www.seeedstudio.com/LoRa-E5-Wireless-Module-p-4745.html
 
 ## Charles's LoRa-E5 breakout board
+
+TARGET: LORA_E5_BREAKOUT
 
 <img src="https://github.com/hallard/LoRa-E5-Breakout/blob/main/pictures/LoRa-E5-Breakout-top.png">
 
@@ -98,9 +154,13 @@ Use LoRa E5 module and added
 
 MCU: STM32WLE5CC
 
+TARGET: RAK3172
+
 https://docs.rakwireless.com/Product-Categories/WisDuo/RAK3172-Module/Datasheet/#description
 
 ## Charles's RAK3172 breakout board
+
+TARGET: RAK3172_BREAKOUT
 
 TBD
 

--- a/TARGET_STM32L0/CMakeLists.txt
+++ b/TARGET_STM32L0/CMakeLists.txt
@@ -1,2 +1,4 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(TARGET_MTB_MURATA_ABZ EXCLUDE_FROM_ALL)

--- a/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/CMakeLists.txt
+++ b/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(mbed-mtb-murata-abz INTERFACE)
+
+target_sources(mbed-mtb-murata-abz
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+)
+
+target_include_directories(mbed-mtb-murata-abz
+    INTERFACE
+        .
+)
+
+target_link_libraries(mbed-mtb-murata-abz INTERFACE mbed-stm32l082xz)

--- a/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/PeripheralPins.c
+++ b/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/PeripheralPins.c
@@ -1,0 +1,191 @@
+/* mbed Microcontroller Library
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ *
+ * Copyright (c) 2016-2021 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ *
+ * Automatically generated from STM32CubeMX/db/mcu/STM32L082CZUx.xml
+ */
+
+#include "PeripheralPins.h"
+#include "mbed_toolchain.h"
+
+//==============================================================================
+// Notes
+//
+// - The pins mentioned Px_y_ALTz are alternative possibilities which use other
+//   HW peripheral instances. You can use them the same way as any other "normal"
+//   pin (i.e. PwmOut pwm(PA_7_ALT0);). These pins are not displayed on the board
+//   pinout image on mbed.org.
+//
+// - The pins which are connected to other components present on the board have
+//   the comment "Connected to xxx". The pin function may not work properly in this
+//   case. These pins may not be displayed on the board pinout image on mbed.org.
+//   Please read the board reference manual and schematic for more information.
+//
+// - Warning: pins connected to the default STDIO_UART_TX and STDIO_UART_RX pins are commented
+//   See https://os.mbed.com/teams/ST/wiki/STDIO for more information.
+//
+//==============================================================================
+
+
+//*** ADC ***
+
+MBED_WEAK const PinMap PinMap_ADC[] = {
+    {PA_0, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 0, 0)}, // BLUE-LED
+    {PA_2, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 2, 0)}, // POT
+    {PA_3, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 3, 0)}, // BUTTON
+    {PA_4, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 4, 0)}, // RED-LED
+    {PA_5, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 5, 0)}, // GREEN-LED
+    {NC,   NC,    0}
+};
+
+MBED_WEAK const PinMap PinMap_ADC_Internal[] = {
+    {ADC_VREF,   ADC_1,    STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // ADC_IN17 // VREFINT
+    {ADC_TEMP,   ADC_1,    STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // ADC_IN18 // VSENSE
+    {NC,       NC,    0}
+};
+
+//*** DAC ***
+
+MBED_WEAK const PinMap PinMap_DAC[] = {
+    {PA_4, DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 1, 0)}, // RED-LED
+    {PA_5, DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 2, 0)}, // GREEN-LED
+    {NC,   NC,    0}
+};
+
+//*** I2C ***
+
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
+    {PA_10, I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF6_I2C1)},
+    {PB_7,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF1_I2C1)},
+    {PB_9,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)}, // SDA
+    {PB_14, I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF5_I2C2)},
+    {NC,    NC,    0}
+};
+
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
+    {PA_9,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF6_I2C1)},
+    {PB_6,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF1_I2C1)},
+    {PB_8,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)}, // SCL
+    {PB_13, I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF5_I2C2)},
+    {NC,    NC,    0}
+};
+
+//*** PWM ***
+
+// TIM21 cannot be used because already used by the us_ticker
+// (update us_ticker_data.h file if another timer is chosen)
+MBED_WEAK const PinMap PinMap_PWM[] = {
+    {PA_0,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 1, 0)}, // TIM2_CH1
+    {PA_1,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 2, 0)}, // TIM2_CH2
+    {PA_2,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 3, 0)}, // TIM2_CH3
+//  {PA_2,       PWM_21, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_TIM21, 1, 0)}, // TIM21_CH1
+    {PA_3,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 4, 0)}, // TIM2_CH4
+//  {PA_3,       PWM_21, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_TIM21, 2, 0)}, // TIM21_CH2
+    {PA_5,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_TIM2, 1, 0)}, // TIM2_CH1
+    {PA_6,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM3, 1, 0)}, // TIM3_CH1
+    {PA_6_ALT0,  PWM_22, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_TIM22, 1, 0)}, // TIM22_CH1
+    {PA_7,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM3, 2, 0)}, // TIM3_CH2
+    {PA_7_ALT0,  PWM_22, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_TIM22, 2, 0)}, // TIM22_CH2
+    {PA_15,      PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_TIM2, 1, 0)}, // TIM2_CH1
+    {PB_0,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM3, 3, 0)}, // TIM3_CH3
+    {PB_1,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM3, 4, 0)}, // TIM3_CH4
+    {PB_3,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 2, 0)}, // TIM2_CH2
+    {PB_4,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM3, 1, 0)}, // TIM3_CH1
+    {PB_4_ALT0,  PWM_22, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF4_TIM22, 1, 0)}, // TIM22_CH1
+    {PB_5,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF4_TIM3, 2, 0)}, // TIM3_CH2
+    {PB_5_ALT0,  PWM_22, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF4_TIM22, 2, 0)}, // TIM22_CH2
+    {PB_10,      PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 3, 0)}, // TIM2_CH3
+    {PB_11,      PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_TIM2, 4, 0)}, // TIM2_CH4
+//  {PB_13,      PWM_21, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_TIM21, 1, 0)}, // TIM21_CH1
+//  {PB_14,      PWM_21, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_TIM21, 2, 0)}, // TIM21_CH2
+    {NC, NC, 0}
+};
+
+//*** SERIAL ***
+
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
+    {PA_2,       UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PA_2_ALT0,  LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_LPUART1)},
+    {PA_9,       UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART1)},
+    {PA_14,      UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PA_14_ALT0, LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_LPUART1)}, // SWCLK
+    {PB_6,       UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_USART1)},
+    {NC,         NC,       0}
+};
+
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
+    {PA_1,       UART_4,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_USART4)},
+    {PA_3,       UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PA_3_ALT0,  LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_LPUART1)},
+    {PA_10,      UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART1)},
+    {PA_13,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_LPUART1)},  // SWDIO
+    {PB_7,       UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_USART1)},
+    {NC,         NC,       0}
+};
+
+MBED_WEAK const PinMap PinMap_UART_RTS[] = {
+    {PA_12,      UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART1)},
+    {PB_12,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_LPUART1)},
+    {PB_14,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_LPUART1)},
+    {NC,         NC,       0}
+};
+
+MBED_WEAK const PinMap PinMap_UART_CTS[] = {
+    {PA_0,       UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PA_11,      UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART1)},
+    {PB_13,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_LPUART1)},
+    {NC,         NC,       0}
+};
+
+//*** SPI ***
+
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
+    {PA_7,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PA_12,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_5,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_15,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI2)},
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
+    {PA_6,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PA_11,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_4,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_14,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI2)},
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_SPI_SCLK[] = {
+    {PA_5,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_3,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_10,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)},
+    {PB_13,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI2)},
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_SPI_SSEL[] = {
+    {PA_4,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PA_15,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI1)},
+    {PB_9,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)},
+    {PB_12,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF0_SPI2)},
+    {NC, NC, 0}
+};
+
+//*** USBDEVICE ***
+
+MBED_WEAK const PinMap PinMap_USB_FS[] = {
+    {PA_11,     USB_FS, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF_NONE)}, // USB_DM
+    {PA_12,     USB_FS, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF_NONE)}, // USB_DP
+//  {PA_13,     USB_FS, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_USB)}, // USB_NOE
+    {NC, NC, 0}
+};

--- a/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/PinNames.h
+++ b/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/PinNames.h
@@ -1,0 +1,163 @@
+/* mbed Microcontroller Library
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ *
+ * Copyright (c) 2016-2021 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ *
+ * Automatically generated from STM32CubeMX/db/mcu/STM32L082CZUx.xml
+ */
+
+/* MBED TARGET LIST: MTB_MURATA_ABZ */
+
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+#include "PinNamesTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ALT0  = 0x100,
+} ALTx;
+
+typedef enum {
+    PA_0       = 0x00,
+    PA_1       = 0x01,
+    PA_2       = 0x02,
+    PA_2_ALT0  = PA_2  | ALT0, // same pin used for alternate HW
+    PA_3       = 0x03,
+    PA_3_ALT0  = PA_3  | ALT0, // same pin used for alternate HW
+    PA_4       = 0x04,
+    PA_5       = 0x05,
+    PA_6       = 0x06,
+    PA_6_ALT0  = PA_6  | ALT0, // same pin used for alternate HW
+    PA_7       = 0x07,
+    PA_7_ALT0  = PA_7  | ALT0, // same pin used for alternate HW
+    PA_8       = 0x08,
+    PA_9       = 0x09,
+    PA_10      = 0x0A,
+    PA_11      = 0x0B,
+    PA_12      = 0x0C,
+    PA_13      = 0x0D,
+    PA_14      = 0x0E,
+    PA_14_ALT0 = PA_14 | ALT0, // same pin used for alternate HW
+    PA_15      = 0x0F,
+    PB_0       = 0x10,
+    PB_1       = 0x11,
+    PB_2       = 0x12,
+    PB_3       = 0x13,
+    PB_4       = 0x14,
+    PB_4_ALT0  = PB_4  | ALT0, // same pin used for alternate HW
+    PB_5       = 0x15,
+    PB_5_ALT0  = PB_5  | ALT0, // same pin used for alternate HW
+    PB_6       = 0x16,
+    PB_7       = 0x17,
+    PB_8       = 0x18,
+    PB_9       = 0x19,
+    PB_10      = 0x1A,
+    PB_11      = 0x1B,
+    PB_12      = 0x1C,
+    PB_13      = 0x1D,
+    PB_14      = 0x1E,
+    PB_15      = 0x1F,
+    PC_13      = 0x2D,
+    PC_14      = 0x2E,
+    PC_15      = 0x2F,
+    PH_0       = 0x70,
+    PH_1       = 0x71,
+
+    /**** ADC internal channels ****/
+
+    ADC_TEMP = 0xF0, // Internal pin virtual value
+    ADC_VREF = 0xF1, // Internal pin virtual value
+    ADC_VBAT = 0xF2, // Internal pin virtual value
+
+    // STDIO for console print
+#ifdef MBED_CONF_TARGET_STDIO_UART_TX
+    CONSOLE_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    CONSOLE_TX = PA_9,
+#endif
+#ifdef MBED_CONF_TARGET_STDIO_UART_RX
+    CONSOLE_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    CONSOLE_RX = PA_10,
+#endif
+
+
+    /**** USB pins ****/
+    USB_DM = PA_11,
+    USB_DP = PA_12,
+
+    /**** OSCILLATOR pins ****/
+    RCC_OSC32_IN = PC_14,
+    RCC_OSC32_OUT = PC_15,
+    RCC_OSC_IN = PH_0,
+    RCC_OSC_OUT = PH_1,
+
+    /**** DEBUG pins ****/
+    SYS_PVD_IN = PB_7,
+    SYS_SWCLK = PA_14,
+    SYS_SWDIO = PA_13,
+    SYS_VREF_OUT_PB0 = PB_0,
+    SYS_VREF_OUT_PB1 = PB_1,
+    SYS_WKUP1 = PA_0,
+    SYS_WKUP2 = PC_13,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+
+// Standardized LED and button names
+#define LED1     PA_4   // Red
+#define LED2     PA_5   // Blue
+#define LED3     PA_0   // Green
+#define BUTTON1  PA_3
+
+// Aliases
+#define I2C_SCL     = PB_8,
+#define I2C_SDA     = PB_9,
+
+#define SPI_MOSI    = PB_15,
+#define SPI_MISO    = PB_14,
+#define SPI_SCK     = PB_13,
+
+#define SD_CS       = PB_12,
+
+#define LCD_A0      = PB_2,
+#define LCD_RESET   = PB_5,
+#define LCD_NCS     = PB_6,
+
+#define LORA_SPI_MOSI   = PA_7,
+#define LORA_SPI_MISO   = PA_6,
+#define LORA_SPI_SCLK   = PB_3,
+#define LORA_CS         = PA_15,
+#define LORA_RESET      = PC_0,
+#define LORA_DIO0       = PB_4,
+#define LORA_DIO1       = PB_1,
+#define LORA_DIO2       = PB_0,
+#define LORA_DIO3       = PC_13,
+#define LORA_ANT_RX     = PA_1,
+#define LORA_ANT_TX     = PC_2,
+#define LORA_ANT_BOOST  = PC_1,
+
+#define FLASH_NCS   = PA_8,
+#define POT         = PA_2, // ADC2 - input !
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/system_clock.c
+++ b/TARGET_STM32L0/TARGET_MTB_MURATA_ABZ/system_clock.c
@@ -1,0 +1,108 @@
+/* mbed Microcontroller Library
+* Copyright (c) 2006-2017 ARM Limited
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+  * This file configures the system clock as follows:
+  *-----------------------------------------------------------------
+  * System clock source | internal 16 MHz
+  *-----------------------------------------------------------------
+  * SYSCLK(MHz)         | 32
+  * AHBCLK (MHz)        | 32
+  * APB1CLK (MHz)       | 32
+  * USB capable         | YES
+  *-----------------------------------------------------------------
+  */
+
+#include "stm32l0xx.h"
+#include "mbed_error.h"
+
+uint8_t SetSysClock_PLL_HSI(void);
+
+
+/**
+  * @brief  Configures the System clock source, PLL Multiplier and Divider factors,
+  *               AHB/APBx prescalers and Flash settings
+  * @note   This function should be called only once the RCC clock configuration
+  *         is reset to the default reset state (done in SystemInit() function).
+  * @param  None
+  * @retval None
+  */
+void SetSysClock(void)
+{
+    if (SetSysClock_PLL_HSI() == 0) {
+        {
+            error("SetSysClock failed\n");
+        }
+    }
+
+    /* Output clock on MCO1 pin(PA8) for debugging purpose */
+    //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
+    //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI48, RCC_MCODIV_1);
+}
+
+/******************************************************************************/
+/*            PLL (clocked by HSI) used as System clock source                */
+/******************************************************************************/
+uint8_t SetSysClock_PLL_HSI(void)
+{
+    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+    RCC_OscInitTypeDef RCC_OscInitStruct;
+    RCC_PeriphCLKInitTypeDef RCC_PeriphClkInit;
+
+    /* The voltage scaling allows optimizing the power consumption when the device is
+       clocked below the maximum system frequency, to update the voltage scaling value
+       regarding system frequency refer to product datasheet. */
+    __PWR_CLK_ENABLE();
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+    /* Enable HSI and HSI48 oscillators and activate PLL with HSI as source */
+    RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48;
+    RCC_OscInitStruct.HSEState            = RCC_HSE_OFF;
+    RCC_OscInitStruct.HSIState            = RCC_HSI_ON;
+    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.HSI48State          = RCC_HSI48_ON; /* For USB and RNG clock */
+    // PLLCLK = (16 MHz * 4)/2 = 32 MHz
+    RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLMUL          = RCC_PLLMUL_4;
+    RCC_OscInitStruct.PLL.PLLDIV          = RCC_PLLDIV_2;
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers */
+    RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 32 MHz
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 32 MHz
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USB;
+    RCC_PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+    if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    /* Output clock on MCO1 pin(PA8) for debugging purpose */
+    //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI, RCC_MCODIV_1); // 16 MHz
+
+    return 1; // OK
+}
+

--- a/custom_targets.json
+++ b/custom_targets.json
@@ -11,6 +11,13 @@
         ],
         "device_name": "STM32F103C8"
     },
+    "MTB_MURATA_ABZ": {
+        "inherits": [
+            "MCU_STM32L082xZ"
+        ],
+        "detect_code": ["0456"],
+        "device_name": "STM32L082CZYx"
+    },
     "STWIN": {
         "inherits": [
             "MCU_STM32L4R9xI"


### PR DESCRIPTION
This follows discussion started in https://github.com/ARMmbed/mbed-os/issues/14695

This pull request takes configuration files from mbed-os-5.15 branch,
and only check build.


NB: "MBEDTLS_CONFIG_HW_SUPPORT" macro is not enabled, as this needs some development in https://github.com/ARMmbed/mbed-os/tree/master/connectivity/drivers/mbedtls/TARGET_STM
Any help is welcome ! :-)


