### PR TITLE
Automatic build update: use mbed_app.json

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -23,6 +23,23 @@ jobs:
             git clone https://github.com/ARMmbed/mbed-os.git
             python3 aci_build.py --all
 
+  CLI1-baremetal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build CL1
+        uses: addnab/docker-run-action@v3
+        with:
+          options: -v ${{ github.workspace }}:/stm32customtargets -w=/stm32customtargets
+          image: mbedos/mbed-os-env:latest
+          shell: bash
+          run: |
+            pip3 list
+            git clone https://github.com/ARMmbed/mbed-os.git
+            python3 aci_build.py --all --baremetal
+
   CLI2:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +56,23 @@ jobs:
             pip3 list
             git clone https://github.com/ARMmbed/mbed-os.git
             python3 aci_build.py --cli2 --all
+
+  CLI2-baremetal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build CL2
+        uses: addnab/docker-run-action@v3
+        with:
+          options: -v ${{ github.workspace }}:/stm32customtargets -w=/stm32customtargets
+          image: mbedos/mbed-os-env:latest
+          shell: bash
+          run: |
+            pip3 list
+            git clone https://github.com/ARMmbed/mbed-os.git
+            python3 aci_build.py --cli2 --all --baremetal
 
   PIN_STANDARD:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Copy custom_targets.json
 cp stm32customtargets/custom_targets.json .
 ````
 
+For some targets, you have to customize the configuration in your local mbed_app.json.
+
+Details are explained for each target below, but you can also use the mbed_app_template.json file as example.
+
 Then build your target with
 
 - CLI1:
@@ -364,6 +368,8 @@ python aci_build.py
 python aci_build.py --cli2
 ```
 
+Note that build is using the mbed_app_template.json file as configuration file.
+
 - Standard Pin Names check should be OK
 
 https://os.mbed.com/docs/mbed-os/latest/apis/standard-pin-names.html
@@ -399,7 +405,9 @@ A full non regression is executed each week-end
 
 ```
 python aci_build.py --all
+python aci_build.py --all --baremetal
 python aci_build.py --all --cli2
+python aci_build.py --all --cli2 --baremetal
 python aci_build.py --all --pin
 ```
 

--- a/mbed_app_template.json
+++ b/mbed_app_template.json
@@ -1,0 +1,66 @@
+{
+    "config": {
+    },
+    "macros": [
+    ],
+    "target_overrides": {
+        "*": {
+        },
+        "MTB_MURATA_ABZ": {
+            "target.components_add":             ["SX1276"],
+            "sx1276-lora-driver.spi-mosi":       "LORA_SPI_MOSI",
+            "sx1276-lora-driver.spi-miso":       "LORA_SPI_MISO",
+            "sx1276-lora-driver.spi-sclk":       "LORA_SPI_SCLK",
+            "sx1276-lora-driver.spi-cs":         "LORA_CS",
+            "sx1276-lora-driver.reset":          "LORA_RESET",
+            "sx1276-lora-driver.dio0":           "LORA_DIO0",
+            "sx1276-lora-driver.dio1":           "LORA_DIO1",
+            "sx1276-lora-driver.dio2":           "LORA_DIO2",
+            "sx1276-lora-driver.dio3":           "LORA_DIO3",
+            "sx1276-lora-driver.txctl":          "LORA_ANT_TX",
+            "sx1276-lora-driver.rxctl":          "LORA_ANT_RX",
+            "sx1276-lora-driver.pwr-amp-ctl":    "LORA_ANT_BOOST"
+        },
+        "GRASSHOPPER": {
+            "target.components_add":             ["SX1276"],
+            "sx1276-lora-driver.spi-mosi":       "LORA_SPI_MOSI",
+            "sx1276-lora-driver.spi-miso":       "LORA_SPI_MISO",
+            "sx1276-lora-driver.spi-sclk":       "LORA_SPI_SCLK",
+            "sx1276-lora-driver.spi-cs":         "LORA_CS",
+            "sx1276-lora-driver.reset":          "LORA_RESET",
+            "sx1276-lora-driver.dio0":           "LORA_DIO0",
+            "sx1276-lora-driver.dio1":           "LORA_DIO1",
+            "sx1276-lora-driver.dio2":           "LORA_DIO2",
+            "sx1276-lora-driver.dio3":           "LORA_DIO3",
+            "sx1276-lora-driver.txctl":          "LORA_ANT_TX",
+            "sx1276-lora-driver.rxctl":          "LORA_ANT_RX",
+            "sx1276-lora-driver.pwr-amp-ctl":    "LORA_ANT_BOOST",
+            "sx1276-lora-driver.tcxo":           "LORA_VDD_TXCO"
+        },
+        "LORA_E5": {
+            "stm32wl-lora-driver.rf_switch_config": 2
+        },
+        "LORA_E5_BREAKOUT": {
+            "stm32wl-lora-driver.rf_switch_config": 2,
+            "stm32wl-lora-driver.debug_tx": "PB_5",
+            "stm32wl-lora-driver.debug_rx": "PB_10",
+            "stm32wl-lora-driver.debug_invert": 1
+        },
+        "LORA_E5_TINY": {
+            "stm32wl-lora-driver.rf_switch_config": 2,
+            "stm32wl-lora-driver.debug_tx": "PB_13",
+            "stm32wl-lora-driver.debug_rx": "PA_9"
+        },
+        "RAK3172": {
+            "stm32wl-lora-driver.rf_switch_config": 2,
+            "stm32wl-lora-driver.crystal_select" : 0
+        },
+        "RAK3172_BREAKOUT": {
+            "stm32wl-lora-driver.rf_switch_config": 2,
+            "stm32wl-lora-driver.crystal_select" : 0,
+            "stm32wl-lora-driver.debug_tx": "PA_10",
+            "stm32wl-lora-driver.debug_rx": "PA_9",
+            "stm32wl-lora-driver.debug_invert": 1
+        }
+    }
+}


### PR DESCRIPTION
3 updates:

- I created a mbed_app_template.json file with all the information taken into the README
Automatic build script is now using the file as the mbed_app.json to ensure better build check.
@hallard 

- when a new target is added, automatic script is failing if custom_targets.json is not updated

- baremetal profile is now tested during weekly non regression build
